### PR TITLE
fix: manual version bump

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/tfvm",
-  "version": "0.0.1",
+  "version": "0.0.2-beta.0",
   "description": "A CLI app for easily switching between Terraform versions",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
lerna was failing to update our package in npm because it was attempting to bump to this version which already exists there, which was caused  when it failed to write the version to our package.json but succeeded at publishing in npm.