### PR TITLE
fix: robustly extract version

### DIFF
--- a/packages/cli/lib/commands/current.js
+++ b/packages/cli/lib/commands/current.js
@@ -16,8 +16,8 @@ async function current () {
       console.log(chalk.white.bold(currentTFVersion + ` (Currently using ${bitType}-bit executable)`))
     } else {
       console.log(
-        chalk.cyan.bold('It appears there is no terraform version running on your computer.', '\n',
-          chalk.green.bold('Run tfvm use <version> to set your terraform version'))
+        chalk.cyan.bold('It appears there is no terraform version running on your computer, or there was an error extracting the version.', '\n',
+          chalk.green.bold('Run tfvm use <version> to set your terraform version, or `terraform -v` to manually check the current version.'))
       )
     }
   } catch (error) {

--- a/packages/cli/lib/util/constants.js
+++ b/packages/cli/lib/util/constants.js
@@ -1,3 +1,6 @@
 export const versionRegEx = /^v[0-9]+.{1}[0-9]+.{1}[0-9]+/
 
+// Uses positive-lookbehind to only match versions preceded by 'Terraform ' but without extracting 'Terraform '
+export const tfCurrVersionRegEx = /(?<=Terraform )v[0-9]+.{1}[0-9]+.{1}[0-9]+/gm
+
 export const settingsFileName = 'settings.json'

--- a/packages/cli/lib/util/tfVersion.js
+++ b/packages/cli/lib/util/tfVersion.js
@@ -1,15 +1,22 @@
 import runShell from './runShell.js'
 import { logger } from './logger.js'
+import { tfCurrVersionRegEx } from './constants.js'
 
 async function getTerraformVersion () {
-  let response = (await runShell('terraform -v'))
+  const response = (await runShell('terraform -v'))
   if (response == null) {
     logger.error('Error getting terraform version')
     return null
   }
-  response = response.split('\n')[0]
-  response = response.split(' ')[1]
-  return response
+  const versionExtractionResult = Array.from(response.matchAll(tfCurrVersionRegEx))
+  if (versionExtractionResult.length === 0) {
+    logger.error('Error extracting terraform version where this is the response from `terraform -v`:\n' + response)
+    return null
+  }
+  // Terraform prints warnings at the start of the output which may contain other tf versions, such as the latest version
+  // Terraform will print the actual current version at the end of the output.
+  // Therefore, we want to grab the last match in the string and return that as our best guess for the current version
+  return versionExtractionResult[versionExtractionResult.length - 1][0]
 }
 
 export default getTerraformVersion


### PR DESCRIPTION
This method improves the robustness of how we are extracting the current terraform version from the output of `terraform -v` by using RegEx.